### PR TITLE
Feature/cartpage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.5.0"
       },
       "devDependencies": {
@@ -2849,6 +2850,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.5.0"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,18 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Mainpage from "./page/MainPage";
 import Header from "./components/Header";
 import CartPage from "./page/CartPage";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 function App() {
-  const [cart, setCart] = useState<string[]>([]);
+  const [cart, setCart] = useState<string[]>(() => {
+    const savedCart = localStorage.getItem("cart");
+    return savedCart ? JSON.parse(savedCart) : [];
+  });
+
+  useEffect(() => {
+    localStorage.setItem("cart", JSON.stringify(cart));
+  }, [cart]);
+
   return (
     <BrowserRouter>
       <Header />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,17 @@ import "./App.css";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Mainpage from "./page/MainPage";
 import Header from "./components/Header";
+import CartPage from "./page/CartPage";
+import { useState } from "react";
 
 function App() {
+  const [cart, setCart] = useState<string[]>([]);
   return (
     <BrowserRouter>
       <Header />
       <Routes>
-        <Route path="/" element={<Mainpage />} />
+        <Route path="/" element={<Mainpage cart={cart} setCart={setCart} />} />
+        <Route path="/cart" element={<CartPage cart={cart} />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import { FaShoppingCart } from "react-icons/fa";
 import "../styles/Header.css";
 
 function Header() {
@@ -13,7 +14,10 @@ function Header() {
       <h1>Cafe Lucy</h1>
       <nav>
         <a href="/">홈</a>
-        <button onClick={handleCartClick}>장바구니</button>
+        <button onClick={handleCartClick}>
+          <FaShoppingCart style={{ marginRight: "6px" }} />
+          장바구니
+        </button>
       </nav>
     </header>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,19 @@
+import { useNavigate } from "react-router-dom";
 import "../styles/Header.css";
 
 function Header() {
+  const navigate = useNavigate();
+
+  const handleCartClick = () => {
+    navigate("/cart");
+  };
+
   return (
     <header>
       <h1>Cafe Lucy</h1>
       <nav>
         <a href="/">홈</a>
+        <button onClick={handleCartClick}>장바구니</button>
       </nav>
     </header>
   );

--- a/src/page/CartPage.tsx
+++ b/src/page/CartPage.tsx
@@ -1,0 +1,22 @@
+interface CartPageProps {
+  cart: string[];
+}
+
+function CartPage({ cart }: CartPageProps) {
+  return (
+    <div>
+      <h2>장바구니</h2>
+      {cart.length === 0 ? (
+        <p>주문한 메뉴가 없습니다.</p>
+      ) : (
+        <ul>
+          {cart.map((item, idx) => (
+            <li key={idx}>{item}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default CartPage;

--- a/src/page/MainPage.tsx
+++ b/src/page/MainPage.tsx
@@ -1,9 +1,11 @@
 import MenuItem from "../components/MenuItem";
-import { useState } from "react";
 
-function Mainpage() {
-  const [cart, setCart] = useState<string[]>([]);
+interface MainPageProps {
+  cart: string[];
+  setCart: React.Dispatch<React.SetStateAction<string[]>>;
+}
 
+function Mainpage({ cart, setCart }: MainPageProps) {
   const handleOrder = (menuName: string) => {
     setCart((prev) => [...prev, menuName]);
   };

--- a/src/page/MainPage.tsx
+++ b/src/page/MainPage.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import MenuItem from "../components/MenuItem";
 
 interface MainPageProps {
@@ -6,8 +7,19 @@ interface MainPageProps {
 }
 
 function Mainpage({ cart, setCart }: MainPageProps) {
+  const navigate = useNavigate();
+
   const handleOrder = (menuName: string) => {
     setCart((prev) => [...prev, menuName]);
+    alert(`${menuName}가 장바구니에 담겼습니다!`);
+  };
+
+  const handlePurchase = () => {
+    if (cart.length === 0) {
+      alert("장바구니가 비었습니다.");
+      return;
+    }
+    navigate("/cart");
   };
 
   return (
@@ -28,19 +40,9 @@ function Mainpage({ cart, setCart }: MainPageProps) {
         price={4000}
         onOrder={() => handleOrder("바닐라라떼")}
       />
-
-      <div className="cart">
-        <h2>🛒 장바구니</h2>
-        {cart.length === 0 ? (
-          <p>주문한 메뉴가 없습니다.</p>
-        ) : (
-          <ul>
-            {cart.map((item, idx) => (
-              <li key={idx}>{item}</li>
-            ))}
-          </ul>
-        )}
-      </div>
+      <button onClick={handlePurchase} style={{ marginTop: "20px" }}>
+        구매하기
+      </button>
     </div>
   );
 }

--- a/src/page/MainPage.tsx
+++ b/src/page/MainPage.tsx
@@ -41,7 +41,7 @@ function Mainpage({ cart, setCart }: MainPageProps) {
         onOrder={() => handleOrder("바닐라라떼")}
       />
       <button onClick={handlePurchase} style={{ marginTop: "20px" }}>
-        구매하기
+        주문하기
       </button>
     </div>
   );

--- a/src/styles/Header.css
+++ b/src/styles/Header.css
@@ -1,27 +1,62 @@
+/* styles/Header.css */
+
 header {
-  background-color: #fff8f0;
-  padding: 1rem 2rem;
-  border-bottom: 2px solid #e0cfc2;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-family: "Cafe24Oneprettynight", sans-serif;
+  background-color: #fff8f0;
+  padding: 16px 32px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  position: sticky;
+  top: 0;
+  z-index: 100;
 }
 
 header h1 {
-  font-size: 2rem;
-  color: #6b4226;
-  margin: 0;
+  font-family: "Stylish", sans-serif;
+  font-size: 28px;
+  color: #6b4c3b;
+  cursor: pointer;
 }
 
-header nav a {
-  font-size: 1.1rem;
-  color: #6b4226;
+nav {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+/* 홈 링크 스타일 */
+nav a {
   text-decoration: none;
-  margin-left: 1.5rem;
-  transition: color 0.3s ease;
+  color: #6b4c3b;
+  font-size: 16px;
+  font-weight: 600;
+  padding: 8px 14px;
+  border: 2px solid #d5b89e;
+  border-radius: 30px;
+  background-color: #fff;
+  transition: all 0.3s ease;
 }
 
-header nav a:hover {
-  color: #a86b4d;
+nav a:hover {
+  background-color: #ffe8d6;
+  color: #3d2c1e;
+  border-color: #c5a68d;
+}
+
+/* 장바구니 버튼 스타일 */
+nav button {
+  background-color: #d5b89e;
+  color: white;
+  border: none;
+  padding: 8px 18px;
+  border-radius: 30px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+nav button:hover {
+  background-color: #c5a68d;
 }


### PR DESCRIPTION
1. 장바구니 페이지 구현
2. 메인 페이지에 있던 장바구니를 장바구니 페이지로 분리 및 APP에서 각각 Props로 전달
4. 주문하기 버튼 추가 및 메뉴 저장 후 장바구니 페이지에 담기도록 로직 변경
5. 헤더에 장바구니로 이동하는 로직 추가
6. 음료 주문하면 장바구니에 자동 저장 로직 추가
7. 헤더 디자인 수정